### PR TITLE
Created qe65_archer2-tds_gcc.md

### DIFF
--- a/QuantumEspresso/qe65_archer2-tds_gcc.md
+++ b/QuantumEspresso/qe65_archer2-tds_gcc.md
@@ -1,0 +1,31 @@
+Build Instructions for QE 6.5 on ARCHER2 TDS
+-----------------------------------------
+
+For version 6.5 on ARCHER using the GCC compilers
+
+```bash
+module swap PrgEnv-cray PrgEnv-gnu
+module load cray-libsci
+module load cray-fftw
+
+tar -xvf qe-6.5.tar.gz
+cd q-e-qe-6.5
+
+export CC=cc
+export FC=ftn
+export F77=ftn
+export F90=ftn
+
+./configure --prefix=${PATH_TO}/q-e-qe-6.5
+```
+
+Build:
+
+```bash
+make all
+```
+
+`${PATH_TO}/q-e-qe-6.4.1/bin` exists now
+
+..NOTE:: probably worth setting ESPRESSO_PSEUDO to
+${PATH_TO}/q-e-qe-6.4.1/pseudo as default


### PR DESCRIPTION
Build instructions for Quantum Espresso 6.5 (GCC compilers) on ARCHER2-TDS