### PR TITLE
Update LAMMPS README: adding link to ARCHER2 build

### DIFF
--- a/LAMMPS/README.md
+++ b/LAMMPS/README.md
@@ -9,11 +9,13 @@ History
 Date | Person | System | Version | Notes
 ---- | -------|--------|---------|------
 2017-06-05 | Andy Turner | Cirrus | 31Mar2017 | Build instructions for Cirrus using GCC 6 compilers and MPT 2.14
+2020-10-15 | Julien Sindt | ARCHER2 | 13Jul2020 | Build instructions for ARCHER2 using GCC 9.3.0 compilers
 
 Build Instructions
 ------------------
 
 * [LAMMPS 31Mar2017 Cirrus Build Instructions (GCC 6, MPT 2.14)](build_lammps_15Mar17_gcc6_mpt214.md)
+* [LAMMPS 15Oct2020 ARCHER2 Build Instructions (GCC 9.3.0)](build_lammps_15Oct2020_gcc930.md)
 
 Notes
 -----


### PR DESCRIPTION
This is to emphasise that an ARCHER2 build exists.