### PR TITLE
GCC Build Scripts for WRF-Chem on ARCHER2

### DIFF
--- a/apps/WRF/ARCHER2-WRFChem-4.2/README.md
+++ b/apps/WRF/ARCHER2-WRFChem-4.2/README.md
@@ -1,0 +1,48 @@
+# WRF-Chem and WPS
+
+For general information on the installation of WRF see e.g.,
+
+https://www2.mmm.ucar.edu/wrf/OnLineTutorial/compilation_tutorial.php
+
+## Install
+
+### `PrgEnv-gnu`
+
+Four prerequisites are installed in the current directory (subdirectory
+`grib2` specified in the script). Flex is needed for the libfl.a library
+(not installed by default with the system flex), and yacc is required
+(not bison, which most system installs of yacc now symlink to).
+
+```
+$ bash ./build-jasper-gnu.sh
+$ bash ./build-libpng-gnu.sh
+$ bash ./build-flex-gnu.sh
+$ bash ./build-yacc-gnu.sh
+```
+
+Then WRF-Chem and WPS can be built
+
+```
+$ bash ./build-wrfchem-gnu.sh
+$ bash ./build-wps-gnu.sh
+```
+
+Note that for `PrgEnv-gnu` we use `gcc/9.3.0` which works with the
+default compiler options from the WRF/WPS configuration. For GCC 10,
+additional options will be required.
+
+Allow 20-30 minutes for this build.
+
+
+## Static geographical data
+
+Download both low resolution and high resolution data as required
+
+```
+wget --no-check-certificate https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_low_res_mandatory.tar.gz
+
+wget --no-check-certificate https://www2.mmm.ucar.edu/wrf/src/wps_files/geog_high_res_mandatory.tar.gz
+
+```
+The high resolution is about 2.9 GB compressed.
+

--- a/apps/WRF/ARCHER2-WRFChem-4.2/build-flex-gnu.sh
+++ b/apps/WRF/ARCHER2-WRFChem-4.2/build-flex-gnu.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# From the default envoronment
+# invoke as "bash ./jasper-build-yacc.sh"
+
+set -e
+
+VERSION='2.6.4'
+
+MY_INSTALL=$(pwd)/flex-${VERSION}
+
+# See https://invisible-island.net/byacc/
+
+# Install [as required]
+# Using the Berkeley FTP site for source code, but there's some
+# info in the Invisible Island website too.
+
+wget https://github.com/westes/flex/releases/download/v2.6.4/flex-${VERSION}.tar.gz
+tar zxvf flex-${VERSION}.tar.gz
+cd flex-${VERSION}
+
+module -s restore PrgEnv-gnu
+module swap gcc gcc/9.3.0
+module list
+
+./configure --prefix=${MY_INSTALL}
+make
+make check
+make install
+

--- a/apps/WRF/ARCHER2-WRFChem-4.2/build-jasper-gnu.sh
+++ b/apps/WRF/ARCHER2-WRFChem-4.2/build-jasper-gnu.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# From the default envoronment
+# invoke as "bash ./jasper-build-gnu.sh"
+
+set -e
+
+MY_INSTALL=`pwd`/grib2
+
+# See https://www.ece.uvic.ca/~frodo/jasper/
+
+# Install [as required]
+# I've preferred this download version over any from github as it does
+# not require the autoconf stage
+# nb. Later versions, e.g., 1.900.28, may fail to compile.
+
+wget https://www.ece.uvic.ca/~frodo/jasper/software/jasper-1.900.1.zip
+unzip jasper-1.900.1.zip
+cd jasper-1.900.1
+
+module -s restore PrgEnv-gnu
+module swap gcc gcc/9.3.0
+module load cray-hdf5
+module load cray-netcdf
+module list
+
+./configure --prefix=${MY_INSTALL}
+make -j 4
+make install
+

--- a/apps/WRF/ARCHER2-WRFChem-4.2/build-libpng-gnu.sh
+++ b/apps/WRF/ARCHER2-WRFChem-4.2/build-libpng-gnu.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# From the default envoronment
+# invoke as "bash ./libpng-build-gnu.sh"
+
+set -e
+
+export MY_INSTALL=`pwd`/grib2
+
+# Install [as required]
+
+wget -O libpng-1.6.37.tar.xz https://sourceforge.net/projects/libpng/files/libpng16/1.6.37/libpng-1.6.37.tar.xz/download
+tar xf libpng-1.6.37.tar.xz
+cd libpng-1.6.37
+
+
+module -s restore PrgEnv-gnu
+module swap gcc gcc/9.3.0
+module load cray-hdf5
+module load cray-netcdf
+module list
+
+./configure --prefix=${MY_INSTALL}
+make -j 4
+make install
+

--- a/apps/WRF/ARCHER2-WRFChem-4.2/build-wps-gnu.sh
+++ b/apps/WRF/ARCHER2-WRFChem-4.2/build-wps-gnu.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# From the default envoronment
+# invoke as "bash ./wps-build-gnu.sh"
+
+set -e
+
+export MY_INSTALL=`pwd`
+
+# Watch out: don't have something with "gcc" here; it will get nuked
+# by sed later on...
+# The main WRF directory is...
+
+export WRF_DIR=${MY_INSTALL}/WRF-4.2.1
+export JASPER_ROOT=${MY_INSTALL}/grib2
+
+# Install [as required]
+wget https://github.com/wrf-model/WPS/archive/v4.2.tar.gz
+tar zxf v4.2.tar.gz
+cd WPS-4.2
+
+./clean
+
+module -s restore PrgEnv-gnu
+module swap gcc gcc/9.3.0
+module load cray-hdf5
+module load cray-netcdf
+
+# Module cray-netcdf is associated with ${NETCDF_DIR}
+# which must be set for the configure stage...
+
+export NETCDF=${NETCDF_DIR}
+
+# JASPER/PNG stuff
+
+export JASPERLIB=${JASPER_ROOT}/lib
+export JASPERINC=${JASPER_ROOT}/include
+
+# The configuration selection is "3" for gcc/gfortran
+# but we must again edit the resultant configure.wps to
+# replace gfortran by ftn etc.
+
+./configure <<EOF
+3
+EOF
+
+sed -i s/gcc/cc/       configure.wps
+sed -i s/mpicc/cc/     configure.wps
+sed -i s/gfortran/ftn/ configure.wps
+sed -i s/mpif90/ftn/   configure.wps
+
+# Compile
+
+./compile
+
+# The make looks like a make -k, so check we have really got three executables
+# at the end:
+
+ls -l *exe

--- a/apps/WRF/ARCHER2-WRFChem-4.2/build-wrfchem-gnu.sh
+++ b/apps/WRF/ARCHER2-WRFChem-4.2/build-wrfchem-gnu.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# From the default module environemnt
+# invoke as "bash ./wrf-build-gcc.sh"
+
+set -e
+
+# Install [uncomment as required]
+wget https://github.com/wrf-model/WRF/archive/v4.2.1.tar.gz
+tar zxf v4.2.1.tar.gz
+cd WRF-4.2.1
+
+module -s restore PrgEnv-gnu
+module swap gcc gcc/9.3.0
+module load cray-hdf5
+module load cray-netcdf
+module list
+
+# Module cray-netcdf is associated with ${NETCDF_DIR}
+# which must be set for the configure stage...
+
+export WRF_CHEM=1
+export WRF_KPP=1
+export NETCDF=${NETCDF_DIR}
+
+FLEX_VERSION='2.6.4'
+export FLEX_LIB_DIR=$(pwd)/../flex-${FLEX_VERSION}/lib/
+
+YACC_VERSION='20210109'
+export YACC_PATH=$(pwd)/../byacc-${YACC_VERSION}/bin/
+
+
+# The configure option is "34": dmpar for gcc/gfortran
+# but we must edit the resulting configure.wrf to replace
+# gfortran by ftn etc.
+
+./configure <<EOF
+34
+1
+EOF
+
+sed -i s/gcc/cc/       configure.wrf
+sed -i s/mpicc/cc/     configure.wrf
+sed -i s/gfortran/ftn/ configure.wrf
+sed -i s/mpif90/ftn/   configure.wrf
+
+sed -i 's/-ll //'  chem/KPP/kpp/kpp-2.1/src/Makefile
+
+sed -i 's/#  YACC=/YACC=${YACC_PATH}\//' chem/KPP/configure_kpp
+
+# Compile "em_real" target
+
+./compile -j 8 em_real

--- a/apps/WRF/ARCHER2-WRFChem-4.2/build-yacc-gnu.sh
+++ b/apps/WRF/ARCHER2-WRFChem-4.2/build-yacc-gnu.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# From the default envoronment
+# invoke as "bash ./jasper-build-yacc.sh"
+
+set -e
+
+VERSION='20210109'
+
+MY_INSTALL=$(pwd)/byacc-${VERSION}
+
+# See https://invisible-island.net/byacc/
+
+# Install [as required]
+# Using the Berkeley FTP site for source code, but there's some
+# info in the Invisible Island website too.
+
+wget https://invisible-mirror.net/archives/byacc/byacc-${VERSION}.tgz
+tar zxvf byacc-${VERSION}.tgz
+cd byacc-${VERSION}
+
+module -s restore PrgEnv-gnu
+module swap gcc gcc/9.3.0
+module list
+
+./configure --prefix=${MY_INSTALL}
+make
+make check
+make install
+


### PR DESCRIPTION
I've copied and extended the WRF build script for ARCHER2 to include the flex and yacc libraries needed for compiling WRF-Chem (with KPP-compiled chemistry schemes).

This is just for the GCC compilers for now - but should be adaptable for the CRAY compilers too?