### PR TITLE
Miniconda3 Documentation

### DIFF
--- a/pyenvs/miniconda3/base/README.md
+++ b/pyenvs/miniconda3/base/README.md
@@ -1,0 +1,21 @@
+Miniconda3 (base)
+=================
+
+This folder contains the documentation for building a general purpose (or base-level) Miniconda3 module
+suitable for various HPC machines.
+
+History
+-------
+
+Date | Person | System | Version | Notes
+---- | -------|--------|---------|------
+2021-03-09 | Michael Bareford | Cirrus | 4.9.7 | Miniconda3 Build instructions for Cirrus using Python 3.8
+
+Build Instructions
+------------------
+
+* [Miniconda3 Cirrus Build Instructions (Python 3.8)](build_miniconda3_base_cirrus_py38.md)
+
+Notes
+-----
+

--- a/pyenvs/miniconda3/base/build_miniconda3_base_cirrus_py38.md
+++ b/pyenvs/miniconda3/base/build_miniconda3_base_cirrus_py38.md
@@ -131,7 +131,7 @@ make install
 ```
 
 Notice that the python configure command for pycuda has two anomalous settings, the `py36` suffix used for the boost python library name and the `11.0` version tag used in the path to the CUDA stub libraries.
-These are not mistakes merely workarounds required to get pycuda to build. These settings do not appear to compromise the PyFR installation (e.g., scaling runs perform as expected).
+These are not mistakes merely workarounds required to get pycuda to build. These settings do not appear to compromise python code running on the Cirrus compute nodes.
 
 
 Install general purpose python packages

--- a/pyenvs/miniconda3/base/build_miniconda3_base_cirrus_py38.md
+++ b/pyenvs/miniconda3/base/build_miniconda3_base_cirrus_py38.md
@@ -1,0 +1,157 @@
+Instructions for building a general purpose Miniconda3 environment on Cirrus
+============================================================================
+
+These instructions are for building a general purpose (or base-level) Miniconda3 environment
+on Cirrus (SGI ICE XA, Intel Xeon Broadwell (CPU) and Cascade Lake (GPU)) using Python 3.8.
+
+As the target machine is Cirrus, the Miniconda3 environment is setup with GPU support in the
+form of pycuda 2020.1 and CUDA 10.1. MPI support is provided by mpi4py 3.0.3 and OpenMPI 4.1.0
+; the OpenMPI libraries having been built against CUDA 10.1.
+
+In addition, the environment provides a suite of general purpose packages (e.g., numpy, scipy,
+pandas and matplotlib) and also supports interactive parallel python using Jupyter notebooks.
+
+Other Miniconda3 environments whose purposes are more tightly defined are expected to be based
+on this module.
+
+
+Setup initial environment
+-------------------------
+
+```bash
+PRFX=/path/to/work
+cd ${PRFX}
+```
+
+Remember to change the setting for `PRFX` to a path appropriate for your Cirrus project.
+
+
+Create and setup a Miniconda3 virtual environment
+-------------------------------------------------
+
+```bash
+PYTHON_LABEL=py38
+PYTHON_LABEL_LONG=python${PYTHON_LABEL:2:1}.${PYTHON_LABEL:3:1}
+
+MINICONDA_TAG=miniconda
+MINICONDA_LABEL=${MINICONDA_TAG}3
+MINICONDA_TITLE=${MINICONDA_LABEL^}
+MINICONDA_VERSION=4.9.2
+MINICONDA_ROOT=${PRFX}/${MINICONDA_LABEL}/${MINICONDA_VERSION}-${PYTHON_LABEL}
+MINICONDA_BASH_SCRIPT=${MINICONDA_TITLE}-${PYTHON_LABEL}_${MINICONDA_VERSION}-Linux-x86_64.sh
+
+mkdir -p ${MINICONDA_LABEL}
+cd ${MINICONDA_LABEL}
+
+wget https://repo.anaconda.com/${MINICONDA_TAG}/${MINICONDA_BASH_SCRIPT}
+chmod 700 ${MINICONDA_BASH_SCRIPT}
+unset PYTHONPATH
+bash ${MINICONDA_BASH_SCRIPT} -b -f -p ${MINICONDA_ROOT}
+rm ${MINICONDA_BASH_SCRIPT}
+cd ${MINICONDA_ROOT}
+
+PATH=${MINICONDA_ROOT}/bin:${PATH}
+conda init --dry-run --verbose > activate.sh
+conda_env_start=`grep -n "# >>> conda initialize >>>" activate.sh | cut -d':' -f 1`
+conda_env_stop=`grep -n "# <<< conda initialize <<<" activate.sh | cut -d':' -f 1`
+
+echo "sed -n '${conda_env_start},${conda_env_stop}p' activate.sh > activate2.sh" > sed.sh
+echo "sed 's/^.//' activate2.sh > activate.sh" >> sed.sh
+echo "rm activate2.sh" >> sed.sh
+. ./sed.sh
+rm ./sed.sh
+
+. ${MINICONDA_ROOT}/activate.sh
+conda update -y -n root --all
+```
+
+
+Build and install mpi4py using OpenMPI 4.1.0
+--------------------------------------------
+
+```bash
+cd ${PRFX}
+
+MPI4PY_LABEL=mpi4py
+MPI4PY_VERSION=3.0.3
+MPI4PY_NAME=${MPI4PY_LABEL}-${MPI4PY_VERSION}
+
+OPENMPI_VERSION=4.1.0
+CUDA_VERSION=10.1
+
+module load nvidia/cuda-${CUDA_VERSION}
+module load nvidia/mathlibs-${CUDA_VERSION}
+module load boost/1.73.0
+module load openmpi/${OPENMPI_VERSION}-cuda-${CUDA_VERSION}
+
+mkdir -p ${MPI4PY_LABEL}
+cd ${MPI4PY_LABEL}
+
+wget https://github.com/${MPI4PY_LABEL}/${MPI4PY_LABEL}/archive/${MPI4PY_VERSION}.tar.gz
+tar -xvzf ${MPI4PY_VERSION}.tar.gz
+rm ${MPI4PY_VERSION}.tar.gz
+
+cd ${MPI4PY_NAME}
+
+MPI4PY_ROOT=${PRFX}/${MPI4PY_LABEL}/${MPI4PY_VERSION}-ompi-${OPENMPI_VERSION}
+python setup.py clean --all
+python setup.py build
+python setup.py install --prefix=${MPI4PY_ROOT}
+
+echo "ROOT=${MPI4PY_ROOT}" > ${MPI4PY_ROOT}/env.sh
+echo "export LIBRARY_PATH=\${ROOT}/lib:\${LIBRARY_PATH}" >> ${MPI4PY_ROOT}/env.sh
+echo "export LD_LIBRARY_PATH=\${ROOT}/lib:\${LD_LIBRARY_PATH}" >> ${MPI4PY_ROOT}/env.sh
+echo "export PYTHONPATH=\${ROOT}/lib/${PYTHON_LABEL_LONG}/site-packages:\${PYTHONPATH}" >> ${MPI4PY_ROOT}/env.sh
+. ${MPI4PY_ROOT}/env.sh
+```
+
+
+Build and install pycuda
+------------------------
+
+```bash
+cd ${PRFX}
+
+PYCUDA_LABEL=pycuda
+PYCUDA_VERSION=2020.1
+PYCUDA_NAME=${PYCUDA_LABEL}-${PYCUDA_VERSION}
+
+mkdir -p ${PYCUDA_LABEL}
+cd ${PYCUDA_LABEL}
+
+wget https://files.pythonhosted.org/packages/46/61/47d3235a4c13eec5a5f03594ddb268f4858734e02980afbcd806e6242fa5/${PYCUDA_NAME}.tar.gz
+tar -xvzf ${PYCUDA_NAME}.tar.gz
+rm ${PYCUDA_NAME}.tar.gz
+
+cd ${PYCUDA_NAME}
+
+python configure.py --cuda-root=${CUDAROOT} --no-use-shipped-boost --boost-python-libname=boost_python-py36 --ldflags="-L/lustre/sw/nvidia/hpcsdk/Linux_x86_64/20.9/cuda/11.0/targets/x86_64-linux/lib/stubs"
+make
+make install
+```
+
+Notice that the python configure command for pycuda has two anomalous settings, the `py36` suffix used for the boost python library name and the `11.0` version tag used in the path to the CUDA stub libraries.
+These are not mistakes merely workarounds required to get pycuda to build. These settings do not appear to compromise the PyFR installation (e.g., scaling runs perform as expected).
+
+
+Install general purpose python packages
+---------------------------------------
+
+```bash
+cd ${MINICONDA_ROOT}
+
+pip install scipy
+pip install matplotlib
+pip install pandas
+pip install ipyparallel
+pip install notebook
+pip install sympy
+```
+
+
+Finish by deactivating the virtual environment
+----------------------------------------------
+
+```bash
+conda deactivate
+```

--- a/pyenvs/miniconda3/base/build_miniconda3_base_cirrus_py38.md
+++ b/pyenvs/miniconda3/base/build_miniconda3_base_cirrus_py38.md
@@ -146,6 +146,7 @@ pip install pandas
 pip install ipyparallel
 pip install notebook
 pip install sympy
+pip install graphviz
 ```
 
 

--- a/pyenvs/miniconda3/ipypar/README.md
+++ b/pyenvs/miniconda3/ipypar/README.md
@@ -1,0 +1,27 @@
+IPyParallel
+===========
+
+This folder contains the documentation for the setting up and running of an interactive parallel python session
+for various HPC machines.
+
+History
+-------
+
+Date | Person | System | Version | Notes
+---- | -------|--------|---------|------
+2021-03-09 | Michael Bareford | Cirrus | 6.3.0 | IPyParallel Config instructions for Cirrus using Python 3.8
+2021-03-09 | Michael Bareford | Cirrus | 6.3.0 | IPyParallel Run instructions for Cirrus using Python 3.8
+
+Config Instructions
+-------------------
+
+* [IPyParallel Cirrus Config Instructions (Python 3.8)](config_ipyparallel_cirrus.md)
+
+Run Instructions
+-------------------
+
+* [IPyParallel Cirrus Run Instructions (Python 3.8)](run_ipyparallel_cirrus.md)
+
+Notes
+-----
+

--- a/pyenvs/miniconda3/ipypar/config_ipyparallel_cirrus.md
+++ b/pyenvs/miniconda3/ipypar/config_ipyparallel_cirrus.md
@@ -1,0 +1,79 @@
+Instructions for setting up an ipyparallel configuration on Cirrus
+==================================================================
+
+These instructions are for setting up an ipyparallel config on Cirrus
+
+The instructions below start with the loading of the `miniconda3/4.9.2-py38` module
+within the user's account on the Cirrus login node.
+
+
+Setup initial environment
+-------------------------
+
+```bash
+module use /lustre/sw/modulefiles.dev
+module load miniconda3/4.9.2-py38
+
+ipython profile create --parallel --profile=mpi
+```
+
+
+Edit the `~/.ipython/profile_mpi/ipcluster_config.py` file
+----------------------------------------------------------
+
+Add the following line.
+
+```bash
+c.IPClusterEngines.engine_launcher_class = 'MPIEngineSetLauncher'
+```
+
+
+Edit the `~/.ipython/profile_mpi/ipengine_config.py` file
+----------------------------------------------------------
+
+Add the following lines.
+
+```bash
+c.EngineFactory.use_mpi = True
+c.MPI.use = 'mpi4py'
+```
+
+
+Submit your Jupyter password
+----------------------------
+
+Start a python session from within your Cirrus login account and
+enter your Jupyter password. In the example below the password
+is `pyjuptr`.
+
+```bash
+In [1]: from notebook.auth import passwd
+In [2]: passwd(algorithm='sha1')
+Enter password: pyjuptr
+Verify password: pyjuptr
+Out[2]: 'sha1:779e3731165d:674576a3aa1446d6e63dbed75d0f90ec3b2a1da7'
+exit()
+```
+
+
+Create the Jupyter configuration file
+-------------------------------------
+
+Return to your Cirrus login account to run the following command.
+
+```bash
+jupyter notebook --generate-config
+```
+
+
+Edit the `~/.jupyter/jupyter_notebook_config.py` file
+-----------------------------------------------------
+
+Add the following lines (the hash must match that generated for your Jupyter password).
+
+```bash
+c.NotebookApp.allow_password_change = False
+c.NotebookApp.password = 'sha1:779e3731165d:674576a3aa1446d6e63dbed75d0f90ec3b2a1da7'
+```
+
+FYI, the ipyparallel package is supported by a [source code repository](https://github.com/ipython/ipyparallel) and [extensive documentation](https://ipyparallel.readthedocs.io/en/latest/).

--- a/pyenvs/miniconda3/ipypar/config_ipyparallel_cirrus.md
+++ b/pyenvs/miniconda3/ipypar/config_ipyparallel_cirrus.md
@@ -1,8 +1,6 @@
 Instructions for setting up an ipyparallel configuration on Cirrus
 ==================================================================
 
-These instructions are for setting up an ipyparallel config on Cirrus
-
 The instructions below start with the loading of the `miniconda3/4.9.2-py38` module
 within the user's account on the Cirrus login node.
 
@@ -59,7 +57,7 @@ exit()
 Create the Jupyter configuration file
 -------------------------------------
 
-Return to your Cirrus login account to run the following command.
+Return to your Cirrus login account and run the following command.
 
 ```bash
 jupyter notebook --generate-config

--- a/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
+++ b/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
@@ -17,12 +17,18 @@ Submit `sbatch submit_ipypar.ll`
 
 #SBATCH --job-name=ipypar
 #SBATCH --time=00:20:00
+#SBATCH --signal=B:TERM@60
 #SBATCH --nodes=1
 #SBATCH --exclusive
 #SBATCH --partition=gpu-cascade
 #SBATCH --qos=gpu
 #SBATCH --gres=gpu:1
 #SBATCH --account=<account_code>
+
+
+IPCLUSTER_START_OUTPUT="ipcluster_start.out"
+IPCLUSTER_STOP_OUTPUT="ipcluster_stop.out"
+JUPYTER_OUTPUT="jupyter.out"
 
 
 # setup termination handler
@@ -33,24 +39,24 @@ function stop_jupyter {
         kill $(pgrep jupyter)
         sleep 5s
     fi
+    echo "Done."
 }
 
 function stop_engines {
     action=$([ $1 -lt 0 ] && echo "terminating" || echo "stopping")
     echo `date` ": ${action} ipyparallel engines..."
-    IPCLUSTER_STOP_OUTPUT=ipcluster_stop.out
-    ipcluster stop --profile=mpi &> $IPCLUSTER_STOP_OUTPUT &
+    ipcluster stop --profile=mpi &> ${IPCLUSTER_STOP_OUTPUT} &
     sleep 5s
+    echo "Done."
 }
 
-function term_processes {
-    stop_jupyter -1
-    stop_engines -1
-    exit -1
+function terminate_processes {
+    stop_jupyter 0
+    stop_engines 0
+    exit 0
 }
 
-trap 'term_processes' TERM
-trap 'term_processes' SIGUSR1
+trap 'terminate_processes' TERM
 
 
 export nodecnt=${SLURM_JOB_NUM_NODES}
@@ -64,23 +70,22 @@ export SLURM_TASKS_PER_NODE="${SLURM_NTASKS_PER_NODE}(x${SLURM_JOB_NUM_NODES})"
 
 cd ${SLURM_SUBMIT_DIR}
 
-rm -f ipcluster_start.out
-rm -f ipcluster_stop.out
-rm -f jupyter_start.out
+rm -f ${IPCLUSTER_START_OUTPUT}
+rm -f ${IPCLUSTER_STOP_OUTPUT}
+rm -f ${JUPYTER_OUTPUT}
 
-# load modules
+
+# load module(s)
 module use /lustre/sw/modulefiles.dev
 module load miniconda3/4.9.2-py38-ml
 
+
 export OMPI_MCA_mca_base_component_show_load_errors=0
 export OMPI_MCA_pml=ob1
-export OMPI_MCA_warn_on_fork=0
+export OMPI_MCA_mpi_warn_on_fork=0
 
-# create the ipyparallel mpi profile
-ipython profile create --parallel --profile=mpi
 
 # start mpi engines
-IPCLUSTER_START_OUTPUT="ipcluster_start.out"
 ipcluster start --debug --profile=mpi -n ${enginecnt} &> ${IPCLUSTER_START_OUTPUT} &
 
 sleepn=0
@@ -99,32 +104,12 @@ while [ : ]; do
     sleepn=$((sleepn+1))
 done
 
+
 # start jupyter notebook
-JUPYTER_START_OUTPUT="jupyter_start.out"
-jupyter notebook --no-browser --port=19888 --ip=0.0.0.0 &> ${JUPYTER_START_OUTPUT} &
+jupyter notebook --no-browser --port=19888 --ip=0.0.0.0 &> ${JUPYTER_OUTPUT} &
 
 
-# sleep until around 5 minutes before end of walltime
-walltime=`squeue -h -j ${SLURM_JOBID} -o "%l"`
-wtlen=${#walltime}
-
-if [ ${wtlen} -eq 5 ]; then
-    mn=`echo ${walltime} | cut -d':' -f 1`
-    waittime=$((mn - 5))
-else
-    hr=`echo ${walltime} | cut -d':' -f 1`
-    mn=`echo ${walltime} | cut -d':' -f 2`
-    waittime=$((hr*60 + mn - 5))
-fi
-
-if [ $waittime -gt 0 ]; then
-    sleep ${waittime}m
-fi
-
-
-stop_jupyter 0
-stop_engines 0
-exit 0
+wait
 ```
 
 
@@ -140,15 +125,16 @@ ssh <username>@cirrus.epcc.ed.ac.uk -L19888:<nodename>:19888
 
 You can now launch a browser on your local machine and begin running your remote Jupyter notebook session, just click [http://localhost:19888](http://localhost:19888).
 Please note, you may not get a login prompt immediately as it takes a minute or two for the Jupyter session to get started (check for the
-presence of a `ipcluster_start.out` file within your first Cirrus session). If you do get a login prompt enter the password specified when
+presence of a non-empty `jupyter.out` file within your first Cirrus session). Once you do get a Jupyter login prompt, enter the password specified when
 setting up the ipyparallel config and you should be presented with a file explorer style interface for your Cirrus account.
 
-Some example jupyter notebooks (`*.ipynb` files) along with supporting python scripts can be found in `/lustre/home/shared/y15/jupyter`.
+Some example Jupyter notebooks (`*.ipynb` files) along with supporting python scripts can be found in `/lustre/home/shared/y15/jupyter`.
 The simplest of these is `ipyparallel-mpi.ipynb`: the notebook uses the `psum.py` script to perform the same summation on all available cores.
 A more interesting example is the `parallelpi.ipynb` notebook, which uses the functions defined in `pydigits.py` and the matplotlib package to
 visualise how frequently digit pairs (00 - 99) occur within the first billion digits of PI. More information concerning this example can be found
 at [https://ipyparallel.readthedocs.io/en/latest/demos.html](https://ipyparallel.readthedocs.io/en/latest/demos.html).
 
-When you have finished with your ipyparallel-enabled Jupyter notebook, simply logout then return to your first Cirrus session and run `scancel -b -s SIGUSR1 <jobid>` with the
-original Slurm job number. This will ensure that all the ipyparallel and Jupyter processes are explicitly shutdown. Finally, the second Cirrus session
-can be shutdown with a simple `exit` command.
+When you have finished with your ipyparallel-enabled Jupyter notebook, simply logout then return to your first Cirrus session and run `scancel -b --signal=TERM <jobid>`
+with the original Slurm job number. This will ensure that all the ipyparallel and Jupyter processes are explicitly shutdown. If you do not call scancel the processes will
+instead be shutdown automatically, 60 seconds before the scheduled end time (see the signal directive in `submit_ipypar.ll`). Finally, the second Cirrus session can be
+shutdown with a simple `exit` command.

--- a/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
+++ b/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
@@ -1,0 +1,154 @@
+Instructions for running an ipyparallel session on Cirrus
+=========================================================
+
+These instructions are for running an ipyparallel session on Cirrus.
+
+The Slurm submission script below requests a GPU node and loads the machine learning
+specific Miniconda3 module before starting the ipyparallel cluster and Jupyter notebook.
+
+This script is suitable therefore for running pytorch commands interactively on a Cirrus
+GPU node. Obviously, the script may need to be altered to suit a different use case. 
+
+Login to your Cirrus account and submit the Slurm script shown below.
+
+
+Submit `sbatch submit_ipypar.ll`
+--------------------------------
+
+```bash
+#!/bin/bash
+
+#SBATCH --job-name=ipypar
+#SBATCH --time=00:20:00
+#SBATCH --nodes=1
+#SBATCH --exclusive
+#SBATCH --partition=gpu-cascade
+#SBATCH --qos=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --account=<account_code>
+
+
+# setup termination handler
+function stop_jupyter {
+    action=$([ $1 -lt 0 ] && echo "terminating" || echo "stopping")
+    echo `date` ": ${action} jupyter notebook..."
+    if pgrep jupyter; then
+        kill $(pgrep jupyter)
+        sleep 5s
+    fi
+}
+
+function stop_engines {
+    action=$([ $1 -lt 0 ] && echo "terminating" || echo "stopping")
+    echo `date` ": ${action} ipyparallel engines..."
+    IPCLUSTER_STOP_OUTPUT=ipcluster_stop.out
+    ipcluster stop --profile=mpi &> $IPCLUSTER_STOP_OUTPUT &
+    sleep 5s
+}
+
+function term_processes {
+    stop_jupyter -1
+    stop_engines -1
+    exit -1
+}
+
+trap 'term_processes' TERM
+
+
+export nodecnt=${SLURM_JOB_NUM_NODES}
+export corecnt=`expr ${nodecnt} \* ${SLURM_CPUS_ON_NODE}`
+export enginecnt=`expr ${corecnt} - 1`
+
+export SLURM_NTASKS=${corecnt}
+export SLURM_NTASKS_PER_NODE=`expr ${SLURM_NTASKS} \/ ${SLURM_JOB_NUM_NODES}`
+export SLURM_TASKS_PER_NODE="${SLURM_NTASKS_PER_NODE}(x${SLURM_JOB_NUM_NODES})"
+
+
+cd ${SLURM_SUBMIT_DIR}
+
+rm -f ipcluster_start.out
+rm -f ipcluster_stop.out
+rm -f jupyter_start.out
+
+# load modules
+module use /lustre/sw/modulefiles.dev
+module load miniconda3/4.9.2-py38-ml
+
+export OMPI_MCA_mca_base_component_show_load_errors=0
+export OMPI_MCA_pml=ob1
+export OMPI_MCA_warn_on_fork=0
+
+# create the ipyparallel mpi profile
+ipython profile create --parallel --profile=mpi
+
+# start mpi engines
+IPCLUSTER_START_OUTPUT=ipcluster_start.out
+ipcluster start --debug --profile=mpi -n $enginecnt &> $IPCLUSTER_START_OUTPUT &
+
+sleepn=0
+while [ : ]; do
+    if grep -q "Engines appear to have started successfully" $IPCLUSTER_START_OUTPUT; then
+        break
+    fi
+    if [ $sleepn -lt 10 ]; then
+        sleep 10s
+    else
+        stop_engines -1
+        exit -1
+    fi
+    sleepn=$((sleepn+1))
+done
+
+# start jupyter notebook
+JUPYTER_START_OUTPUT=jupyter_start.out
+jupyter notebook --no-browser --port=19888 --ip=0.0.0.0 &> $JUPYTER_START_OUTPUT &
+
+
+# sleep until around 5 minutes before end of walltime
+walltime=`squeue -h -j ${SLURM_JOBID} -o "%l"`
+wtlen=${#walltime}
+
+if [ $wtlen -eq 5 ]; then
+    mn=`echo $walltime | cut -d':' -f 1`
+    waittime=$((mn - 5))
+else
+    hr=`echo $walltime | cut -d':' -f 1`
+    mn=`echo $walltime | cut -d':' -f 2`
+    waittime=$((hr*60 + mn - 5))
+fi
+
+if [ $waittime -gt 0 ]; then
+    sleep ${waittime}m
+fi
+
+
+stop_jupyter 0
+stop_engines 0
+exit 0
+```
+
+
+Once the job is running, execute `sacct -j <jobnumber> --format=NodeList%32` with the returned job number
+and from the `sacct` output extract the name of the first node assigned to the job.
+
+Now start a second Cirrus login session using the ssh command given below.
+
+```bash
+ssh <username>@cirrus.epcc.ed.ac.uk -L19888:<nodename>:19888
+```
+
+
+You can now launch a browser on your local machine and begin running your remote Jupyter notebook session, just click [http://localhost:19888](http://localhost:19888).
+Please note, you may not get a login prompt immediately as it takes a minute or two for the Jupyter session to get started (check for the
+presence of a `ipcluster_start.out` file within your first Cirrus session). If you do get a login prompt enter the password specified when
+setting up the ipyparallel config and you should be presented with a file explorer style interface for your Cirrus account.
+
+Some example jupyter notebooks (`*.ipynb` files) along with supporting python scripts can be found in `/lustre/home/shared/y15/jupyter`.
+The simplest of these is `ipyparallel-mpi.ipynb`: the notebook uses the `psum.py` script to perform the same summation on all available cores.
+A more interesting example is the `parallelpi.ipynb` notebook, which uses the functions defined in `pydigits.py` and the matplotlib package to
+visualise how frequently digit pairs (00 - 99) occur within the first billion digits of PI. More information concerning this example can be found
+at [https://ipyparallel.readthedocs.io/en/latest/demos.html](https://ipyparallel.readthedocs.io/en/latest/demos.html).
+
+When you have finished with your ipyparallel-enabled Jupyter notebook, simply logout then return to your first Cirrus session and run scancel with the
+original Slurm job number. This will ensure that all the ipyparallel and Jupyter processes are explicitly shutdown. Finally, the second Cirrus session
+can be shutdown with a simple exit command.

--- a/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
+++ b/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
@@ -19,7 +19,6 @@ Submit `sbatch submit_ipypar.ll`
 #SBATCH --time=00:20:00
 #SBATCH --signal=B:TERM@60
 #SBATCH --nodes=1
-#SBATCH --exclusive
 #SBATCH --partition=gpu-cascade
 #SBATCH --qos=gpu
 #SBATCH --gres=gpu:1

--- a/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
+++ b/pyenvs/miniconda3/ipypar/run_ipyparallel_cirrus.md
@@ -1,11 +1,8 @@
 Instructions for running an ipyparallel session on Cirrus
 =========================================================
 
-These instructions are for running an ipyparallel session on Cirrus.
-
 The Slurm submission script below requests a GPU node and loads the machine learning
 specific Miniconda3 module before starting the ipyparallel cluster and Jupyter notebook.
-
 This script is suitable therefore for running pytorch commands interactively on a Cirrus
 GPU node. Obviously, the script may need to be altered to suit a different use case. 
 
@@ -149,6 +146,6 @@ A more interesting example is the `parallelpi.ipynb` notebook, which uses the fu
 visualise how frequently digit pairs (00 - 99) occur within the first billion digits of PI. More information concerning this example can be found
 at [https://ipyparallel.readthedocs.io/en/latest/demos.html](https://ipyparallel.readthedocs.io/en/latest/demos.html).
 
-When you have finished with your ipyparallel-enabled Jupyter notebook, simply logout then return to your first Cirrus session and run scancel with the
+When you have finished with your ipyparallel-enabled Jupyter notebook, simply logout then return to your first Cirrus session and run `scancel` with the
 original Slurm job number. This will ensure that all the ipyparallel and Jupyter processes are explicitly shutdown. Finally, the second Cirrus session
-can be shutdown with a simple exit command.
+can be shutdown with a simple `exit` command.

--- a/pyenvs/miniconda3/ml/README.md
+++ b/pyenvs/miniconda3/ml/README.md
@@ -1,0 +1,21 @@
+Miniconda3 (machine learning)
+=============================
+
+This folder contains the documentation for building a Miniconda3 module suitable for machine learning
+applications for various HPC machines.
+
+History
+-------
+
+Date | Person | System | Version | Notes
+---- | -------|--------|---------|------
+2021-03-09 | Michael Bareford | Cirrus | 4.9.7 | Miniconda3 Build instructions for Cirrus using Python 3.8
+
+Build Instructions
+------------------
+
+* [Miniconda3 Cirrus Build Instructions (Python 3.8)](build_miniconda3_ml_cirrus_py38.md)
+
+Notes
+-----
+

--- a/pyenvs/miniconda3/ml/build_miniconda3_ml_cirrus_py38.md
+++ b/pyenvs/miniconda3/ml/build_miniconda3_ml_cirrus_py38.md
@@ -1,0 +1,99 @@
+Instructions for building a machine learning Miniconda3 environment on Cirrus
+=============================================================================
+
+These instructions are for building a machine learning Miniconda3 environment on Cirrus
+(SGI ICE XA, Intel Xeon Broadwell (CPU) and Cascade Lake (GPU)) using Python 3.8.
+
+The build for this Miniconda3 environment is based on `miniconda3/4.9.2-py38`.
+It provides various machine learning frameworks such as TensorFlow 2.3.0 and PyTorch 1.7.1.
+Crucially, the Horovod package allows those frameworks to utilise multiple GPUS distributed
+across multiple compute nodes.
+
+
+Setup initial environment
+-------------------------
+
+```bash
+PRFX=/path/to/work
+cd ${PRFX}
+```
+
+Remember to change the setting for `PRFX` to a path appropriate for your Cirrus project.
+
+
+Set the version environment variables
+-------------------------------------
+
+```bash
+CUDA_VERSION=10.1
+NCCL_VERSION=2.8.3
+OPENMPI_VERSION=4.1.0
+PYTHON_LABEL=py38
+MINICONDA_VERSION=4.9.2
+```
+
+
+Load the required modules
+-------------------------
+
+```bash
+module load nvidia/cuda-${CUDA_VERSION}
+module load nvidia/mathlibs-${CUDA_VERSION}
+module load boost/1.73.0
+module load openmpi/${OPENMPI_VERSION}-cuda-${CUDA_VERSION}
+module load gcc/8.2.0
+
+module use /lustre/sw/modulefiles.dev
+module load miniconda3/${MINICONDA_VERSION}-${PYTHON_LABEL}
+module load cmake/3.17.3
+```
+
+
+Create new python environment based on the (general purpose) miniconda3 loaded above
+------------------------------------------------------------------------------------
+
+```bash
+MINICONDA_ML_ROOT=/lustre/sw/miniconda3/${MINICONDA_VERSION}-${PYTHON_LABEL}-ml
+
+python -m venv --system-site-packages ${MINICONDA_ML_ROOT}
+
+. ${MINICONDA_ML_ROOT}/bin/activate
+pip install --upgrade pip
+```
+
+
+Install the machine learning packages
+-------------------------------------
+
+```bash
+pip install torch
+pip install torchvision
+pip install pytorch-lightning
+pip install pytorch-lightning-bolts
+pip install pytorch-lightning-bolts["extra"]
+pip install wandb
+pip install gym
+
+pip install tensorflow==2.3.0
+pip install tensorflow-gpu==2.3.0
+pip install scikit-learn
+```
+
+
+Install Horovod linking with the Nvidia Collective Communications Library (NCCL)
+--------------------------------------------------------------------------------
+
+```bash
+NCCL_ROOT=/lustre/sw/nvidia/nccl/${NCCL_VERSION}-cuda-${CUDA_VERSION}
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${NCCL_ROOT}/lib
+HOROVOD_NCCL_HOME=${NCCL_ROOT} HOROVOD_GPU_OPERATIONS=NCCL pip install --no-cache-dir horovod
+```
+
+
+Finish by deactivating the virtual environment
+----------------------------------------------
+
+```bash
+deactivate
+module unload miniconda3/4.9.2-py38
+```


### PR DESCRIPTION
These new files concern two Miniconda3-based modules that have been installed on Cirrus.

miniconda3/4.9.2-py38: a general purpose miniconda environment that supports interactive parallel python using Jupyter notebooks.

miniconda3/4.9.2-py38-ml: a miniconda environment for machine learning; it features pytorch and tensorflow, and, through the use of horovod, supports distributed machine learning also.

The documentation also covers how to setup an interactive parallel python session.