### PR TITLE
Mbareford/restore cmake and gnu parallel

### DIFF
--- a/utils/cmake/README.md
+++ b/utils/cmake/README.md
@@ -1,0 +1,20 @@
+CMake
+=====
+
+This folder contains instructions for building CMake on UK HPC systems.
+
+CMake is an open-source, cross-platform family of tools designed to build, test and package software.
+
+History
+-------
+
+ Date | Person | System | Version | Notes
+ ---- | ------ | ------ | ------- | -----
+ 2020-11-23 | Michael Bareford | Cirrus | 3.17.3 | GCC 6.3.0
+
+Build Instructions
+------------------
+
+See the [CMake home page](https://cmake.org/).
+
+* [CMake 3.17.3 Cirrus Build Instructions (GCC 6)](build_cmake_3.17.3_cirrus_gcc6.md)

--- a/utils/cmake/README.md
+++ b/utils/cmake/README.md
@@ -3,7 +3,9 @@ CMake
 
 This folder contains instructions for building CMake on UK HPC systems.
 
-CMake is an open-source, cross-platform family of tools designed to build, test and package software.
+CMake is an open-source, cross-platform family of tools designed to build, test and package software,
+see the [CMake home page](https://cmake.org/).
+
 
 History
 -------
@@ -12,9 +14,8 @@ History
  ---- | ------ | ------ | ------- | -----
  2020-11-23 | Michael Bareford | Cirrus | 3.17.3 | GCC 6.3.0
 
+
 Build Instructions
 ------------------
-
-See the [CMake home page](https://cmake.org/).
 
 * [CMake 3.17.3 Cirrus Build Instructions (GCC 6)](build_cmake_3.17.3_cirrus_gcc6.md)

--- a/utils/cmake/build_cmake_3.17.3_cirrus_gcc6.md
+++ b/utils/cmake/build_cmake_3.17.3_cirrus_gcc6.md
@@ -1,0 +1,49 @@
+Instructions for building CMake 3.17.3 on Cirrus
+================================================
+
+These instructions are for building CMake 3.17.3 on Cirrus (Intel Xeon E5-2695, Broadwell) using GCC 6.
+
+
+Setup initial environment
+-------------------------
+
+```bash
+PRFX=/path/to/work  # e.g., /lustre/sw
+
+CMAKE_LABEL=cmake
+CMAKE_VERSION=3.17.3
+CMAKE_NAME=${CMAKE_LABEL}-${CMAKE_VERSION}
+
+mkdir -p ${PRFX}/${CMAKE_LABEL}
+cd ${PRFX}/${CMAKE_LABEL}
+
+module load gcc/6.3.0
+export OPENSSL_ROOT_DIR=/lustre/sw/openssl/1.1.1g
+```
+
+Remember to change the setting for `PRFX` to a path appropriate for your Cirrus project.
+
+
+Download source code
+--------------------
+
+```bash
+wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_NAME}.tar.gz
+
+tar -xzf ${CMAKE_NAME}.tar.gz
+
+rm ${CMAKE_NAME}.tar.gz
+cd ${CMAKE_NAME}
+```
+
+
+Configure and build CMake
+-------------------------
+
+```bash
+./configure CC=gcc CXX=g++ --prefix=${PRFX}/${CMAKE_LABEL}/${CMAKE_VERSION}
+
+gmake
+gmake install
+gmake clean
+```

--- a/utils/gnu-parallel/README.md
+++ b/utils/gnu-parallel/README.md
@@ -1,0 +1,21 @@
+GNU Parallel
+============
+
+This folder contains instructions for building GNU Parallel on UK HPC systems.
+
+GNU parallel is a shell tool for executing jobs in parallel using one or more computers, 
+see the [GNU Parallel home page](https://www.gnu.org/software/parallel/). 
+
+
+History
+-------
+
+ Date | Person | System | Version | Notes
+ ---- | ------ | ------ | ------- | -----
+ 2020-11-23 | Michael Bareford | Cirrus | 20200522 | GCC 6.3.0
+
+
+Build Instructions
+------------------
+
+* [GNU Parallel 20200522 Cirrus Build Instructions (GCC 6)](build_gnu-parallel_20200522_cirrus_gcc6.md)

--- a/utils/gnu-parallel/build_gnu-parallel_20200522_cirrus_gcc6.md
+++ b/utils/gnu-parallel/build_gnu-parallel_20200522_cirrus_gcc6.md
@@ -1,0 +1,49 @@
+Instructions for building GNU Parallel 20200522 on Cirrus
+=========================================================
+
+These instructions are for building GNU Parallel 20200522 on Cirrus (Intel Xeon E5-2695, Broadwell) using GCC 6.
+
+
+Setup initial environment
+-------------------------
+
+```bash
+PRFX=/path/to/work  # e.g., /lustre/sw
+
+GNUPAR_LABEL=gnu-parallel
+GNUPAR_VERSION=20200522
+GNUPAR_NAME=${GNUPAR_LABEL}-${GNUPAR_VERSION}
+
+mkdir -p ${PRFX}/${GNUPAR_LABEL}
+cd ${PRFX}/${GNUPAR_LABEL}
+
+module load gcc/6.3.0
+```
+
+Remember to change the setting for `PRFX` to a path appropriate for your Cirrus project.
+
+
+Download source code
+--------------------
+
+```bash
+wget https://ftpmirror.gnu.org/parallel/parallel-${GNUPAR_VERSION}.tar.bz2
+
+bzip2 -dc parallel-${GNUPAR_VERSION}.tar.bz2 | tar xvf -
+
+rm parallel-${GNUPAR_VERSION}.tar.bz2
+mv parallel-${GNUPAR_VERSION} ${GNUPAR_NAME}
+cd ${GNUPAR_NAME}
+```
+
+
+Configure and build GNU Parallel
+--------------------------------
+
+```bash
+./configure --prefix=${PRFX}/${GNUPAR_LABEL}/${GNUPAR_VERSION}
+
+make
+make install
+make clean
+```


### PR DESCRIPTION
These instructions were somehow lost around the time the repo structure was reorganised in Dec 2020.