### PR TITLE
Archer2 siesta b4

### DIFF
--- a/apps/SIESTA/README.md
+++ b/apps/SIESTA/README.md
@@ -8,12 +8,14 @@ History
 
 Date | Person | Version | Notes
 ---- | -------|---------|------
-2017-01-31 | Adrian Jackson | 4.1-b2 | 
+2017-01-31 | Adrian Jackson | 4.1-b2 | For ARCHER - deprecated |
+2022-02-16 | David Henty | 4.1-b4 | For ARCHER2 | 
 
 Build Instructions
 ------------------
 
-* [SIESTA 4.1-b2 ARCHER Intel Compilers Build Instructions](build_siesta_4.1_intel_ivybrg.md)
+# * [SIESTA 4.1-b2 ARCHER Intel Compilers Build Instructions](build_siesta_4.1_intel_ivybrg.md)
+[SIESTA 4.1-b2 ARCHER2 GNU Compilers Build Instructions](build_siesta_4.4_amd_epyc.md)
 
 Notes
 -----

--- a/apps/SIESTA/README.md
+++ b/apps/SIESTA/README.md
@@ -14,8 +14,7 @@ Date | Person | Version | Notes
 Build Instructions
 ------------------
 
-# * [SIESTA 4.1-b2 ARCHER Intel Compilers Build Instructions](build_siesta_4.1_intel_ivybrg.md)
-[SIESTA 4.1-b2 ARCHER2 GNU Compilers Build Instructions](build_siesta_4.4_amd_epyc.md)
+* [SIESTA 4.1-b2 ARCHER2 GNU Compilers Build Instructions](build_siesta_4.4_amd_epyc.md)
 
 Notes
 -----

--- a/apps/SIESTA/README.md
+++ b/apps/SIESTA/README.md
@@ -14,7 +14,7 @@ Date | Person | Version | Notes
 Build Instructions
 ------------------
 
-* [SIESTA 4.1-b2 ARCHER2 GNU Compilers Build Instructions](build_siesta_4.4_amd_epyc.md)
+* [SIESTA 4.1-b4 ARCHER2 GNU Compilers Build Instructions](build_siesta_4.4_amd_epyc.md)
 
 Notes
 -----

--- a/apps/SIESTA/README.md
+++ b/apps/SIESTA/README.md
@@ -14,7 +14,7 @@ Date | Person | Version | Notes
 Build Instructions
 ------------------
 
-* [SIESTA 4.1-b4 ARCHER2 GNU Compilers Build Instructions](build_siesta_4.4_amd_epyc.md)
+* [SIESTA 4.1-b4 ARCHER2 GNU Compilers Build Instructions](build_siesta_4.1_amd_epyc.md)
 
 Notes
 -----

--- a/apps/SIESTA/build_siesta_4.1_amd_epyc.md
+++ b/apps/SIESTA/build_siesta_4.1_amd_epyc.md
@@ -1,0 +1,79 @@
+Instructions for compiling SIESTA 4.1-b4 for ARCHER using Intel compilers
+=========================================================================
+
+These instructions are for compiling SIESTA 4.1-b4 on ARCHER2 (AMD EPYC
+processors) using the GNU compilers
+
+Download and Unpack the source code
+-------------------------------------------
+
+Download and unpack the source
+
+```bash
+wget wget https://launchpad.net/siesta/4.1/4.1-b4/+download/siesta-4.1-b4.tar.gz
+tar zxvf siesta-4.1-b4.tar.gz
+```
+
+Setup correct modules
+---------------------
+
+Switch to the GNU programming environment:
+
+```bash
+module swap PrgEnv-cray PrgEnv-gnu
+```
+
+
+Configure the build
+-------------------
+
+Go into the source build directory and run the setup script
+
+
+```bash
+cd siesta-4.1-b4/Obj
+sh ../Src/obj_setup.sh
+```
+
+This will create some files for the compilation.  As we are building with
+the GNU compilers copy the appropriate make configuration file
+
+```bash
+cp gfortran.make arch.make
+```
+
+Edit the arch.make file to set the correct compilers.
+
+```bash
+SIESTA_ARCH = cray-gcc
+
+CC = cc
+FPP = $(FC) -E -P -x c
+FC = ftn
+FC_SERIAL = ftn
+
+FFLAGS = -O2 -fPIC -ftree-vectorize -fallow-argument-mismatch 
+```
+
+Ensure that optimised maths libraries will be used in the compilation by editing the arch.make file.
+
+```bash
+COMP_LIBS =
+```
+
+Enable MPI by editing the arch.make file and adding the following.
+
+```bash
+MPI_INTERFACE = libmpi_f90.a
+MPI_INCLUDE = .
+FPPFLAGS += -DMPI
+```
+
+Build the executable using make
+
+```bash
+make
+```
+
+This should produce the executable (called siesta) in the Obj directory (where you have been compiling the code).
+

--- a/apps/SIESTA/build_siesta_4.1_amd_epyc.md
+++ b/apps/SIESTA/build_siesta_4.1_amd_epyc.md
@@ -1,5 +1,5 @@
-Instructions for compiling SIESTA 4.1-b4 for ARCHER using Intel compilers
-=========================================================================
+Instructions for compiling SIESTA 4.1-b4 for ARCHER2 using GNU compilers
+========================================================================
 
 These instructions are for compiling SIESTA 4.1-b4 on ARCHER2 (AMD EPYC
 processors) using the GNU compilers


### PR DESCRIPTION
Added instructions for compiling SIESTA on ARCHER2 and removed out-of-date ARCHER instructions (which use Intel compilers).