### PR TITLE
Added instructions for UCX 1.9.0.

### DIFF
--- a/libs/ucx/README.md
+++ b/libs/ucx/README.md
@@ -15,13 +15,18 @@ History
 
  Date | Person | System | Version | Notes
  ---- | ------ | ------ | ------- | -----
- 2022-03-16 | Michael Bareford | Cirrus | 1.12.0 | GCC 8.2.0
+ 2022-03-17 | Michael Bareford | Cirrus | 1.9.0 | GCC 8.2.0
+ 2022-03-17 | Michael Bareford | Cirrus | 1.12.0 | GCC 8.2.0
 
 Build Instructions
 ------------------
 
+* [UCX 1.9.0 Cirrus Build Instructions (GCC 8)](build_ucx_1.9.0_cirrus_gcc8.md)
 * [UCX 1.12.0 Cirrus Build Instructions (GCC 8)](build_ucx_1.12.0_cirrus_gcc8.md)
 
 Notes
 -----
 
+There is currently an issue when using UCX 1.12.0 with OpenMPI 4.1.2 on Cirrus: a simple MPI broadcast gives
+`Segmentation fault: address not mapped to object at address (nil)` from within the UCX `libucs.so.0` library.
+The workaround is to use OpenMPI with UCX 1.9.0 instead.

--- a/libs/ucx/build_ucx_1.9.0_cirrus_gcc8.md
+++ b/libs/ucx/build_ucx_1.9.0_cirrus_gcc8.md
@@ -1,0 +1,63 @@
+Instructions for building UCX 1.9.0 on Cirrus
+=============================================
+
+These instructions are for building UCX 1.9.0 on Cirrus (SGI ICE XA, Intel Xeon Broadwell (CPU) and Cascade Lake (GPU)) using gcc 8.2.0.
+
+
+Setup initial environment
+-------------------------
+
+```bash
+PRFX=/path/to/work # e.g., /scratch/sw
+UCX_LABEL=ucx
+UCX_VERSION=1.9.0
+UCX_NAME=${UCX_LABEL}-${UCX_VERSION}
+
+mkdir -p ${PRFX}/${UCX_LABEL}
+cd ${PRFX}/${UCX_LABEL}
+
+wget https://github.com/openucx/${UCX_LABEL}/archive/refs/tags/v${UCX_VERSION}.tar.gz
+tar xzf v${UCX_VERSION}.tar.gz
+rm v${UCX_VERSION}.tar.gz
+cd ${UCX_NAME}
+
+module load libtool/2.4.6
+
+./autogen.sh
+
+module load zlib/1.2.11
+```
+
+Remember to change the setting for `PRFX` to a path appropriate for your Cirrus project.
+
+
+Build and install UCX for CPU
+-----------------------------
+
+```bash
+module load gcc/8.2.0
+
+./configure CC=gcc CXX=g++ FC=gfortran \
+  --prefix=${PRFX}/${UCX_LABEL}/${UCX_VERSION}
+
+make
+make install
+make clean
+```
+
+
+Build and install UCX for GPU (CUDA 11.6)
+-----------------------------------------
+
+```bash
+module load nvidia/nvhpc-nompi/22.2
+
+./configure CC=gcc CXX=g++ FC=gfortran \
+  --with-cuda=${NVHPC_ROOT}/cuda/11.6 \
+  --with-mlx5-dv \
+  --prefix=${PRFX}/${UCX_LABEL}/${UCX_VERSION}-cuda-11.6
+
+make
+make install
+make clean
+```


### PR DESCRIPTION
It was necessary to reinstate the build instructions due to error that occurs when using UCX 1.12.0 with OpenMPI 4.1.2,
see note at end of UCX "README.md".