### PR TITLE
fixing some environment variable references

### DIFF
--- a/apps/ParaView/ARCHER2_paraview5.9.1offscreen_gcc10.1.md
+++ b/apps/ParaView/ARCHER2_paraview5.9.1offscreen_gcc10.1.md
@@ -92,8 +92,8 @@ make install
 
 
 ```
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/paraview/build/install/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/paraview/build/install/lib64
 export PATH=$PATH:${PV_PATH}/paraview/build/install/bin
-export PYTHONPATH=$PYTHONPATH:${{PV_PATH}/paraview/build/install/lib64/python3.8/site-packages
+export PYTHONPATH=$PYTHONPATH:${PV_PATH}/paraview/build/install/lib64/python3.8/site-packages
 ```
 

--- a/apps/ParaView/ARCHER2_paraview5.9.1offscreen_raytracing_gcc10.1.md
+++ b/apps/ParaView/ARCHER2_paraview5.9.1offscreen_raytracing_gcc10.1.md
@@ -114,13 +114,13 @@ make install
 
 
 ```
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/paraview/build/install/lib64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/ospray/2.1.0/ospray/lib64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/ospray/2.1.0/openvkl/lib64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/ospray/2.1.0/embree/lib64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/llvm/lib
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/mesa/21.0.1/lib64
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$(PV_PATH)/paraview/build/install/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/paraview/build/install/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/ospray/2.1.0/ospray/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/ospray/2.1.0/openvkl/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/ospray/2.1.0/embree/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/llvm/lib
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/mesa/21.0.1/lib64
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${PV_PATH}/paraview/build/install/lib64
 export PATH=$PATH:${PV_PATH}/paraview/build/install/bin
-export PYTHONPATH=$PYTHONPATH:${{PV_PATH}/paraview/build/install/lib64/python3.8/site-packages
+export PYTHONPATH=$PYTHONPATH:${PV_PATH}/paraview/build/install/lib64/python3.8/site-packages
 ```


### PR DESCRIPTION
user pointed out there were some parentheses () which should have been brackets {} (s/the American word/the correct British word/ where applicable) 