### PR TITLE
Adds Cirrus Intel VASP 6.3.2 build instructions

### DIFF
--- a/apps/VASP/6.3.2_makefile.include.Cirrus_Intel
+++ b/apps/VASP/6.3.2_makefile.include.Cirrus_Intel
@@ -1,0 +1,90 @@
+# Default precompiler options
+CPP_OPTIONS = -DHOST=\"SGIICEXA-Intel20-HMPT225\" \
+              -DMPI -DMPI_BLOCK=8000 -Duse_collective \
+              -DscaLAPACK \
+              -DCACHE_SIZE=4000 \
+              -Davoidalloc \
+              -Dvasp6 \
+              -Duse_bse_te \
+              -Dtbdyn \
+              -Dfock_dblbuf \
+              -D_OPENMP
+
+CPP        = fpp -f_com=no -free -w0  $*$(FUFFIX) $*$(SUFFIX) $(CPP_OPTIONS)
+
+FC          = mpif08 -qopenmp
+FCL         = mpif08 -qopenmp
+
+FREE        = -free -names lowercase
+
+FFLAGS     = -assume byterecl -w
+OFLAG      = -O3 -ip -fno-alias -unroll-aggressive -qopt-prefetch -use-intel-optimized-headers -no-prec-div
+OFLAG_IN   = $(OFLAG)
+DEBUG      = -O0
+
+OBJECTS     = fftmpiw.o fftmpi_map.o fftw3d.o fft3dlib.o
+
+LLIBS      = -L${MKLROOT}/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_sgimpt_lp64 -qopenmp -lpthread -lm -ldl
+
+# Redefine the standard list of O1 and O2 objects
+OBJECTS_O1 += fftw3d.o fftmpi.o fftmpiw.o
+OBJECTS_O2 += fft3dlib.o
+
+# For what used to be vasp.5.lib
+CPP_LIB    = $(CPP)
+FC_LIB     = $(FC)
+CC_LIB     = mpiicc -cc=icc
+CCX        = mpiicpc
+CCX_LIB    = mpiicpc
+CFLAGS_LIB = -O
+FFLAGS_LIB = -O1
+FREE_LIB   = $(FREE)
+
+OBJECTS_LIB = linpack_double.o
+
+# For the parser library
+CXX_PARS   = mpiicpc -cxx=icpc
+
+#LIBS       += parser
+LLIBS      += -Lparser -lparser -lstdc++
+
+# Normally no need to change this
+SRCDIR     = ../../src
+BINDIR     = ../../bin
+
+
+##
+## Customize as of this point! Of course you may change the preceding
+## part of this file as well if you like, but it should rarely be
+## necessary ...
+##
+# Intel MKL for FFTW, BLAS, LAPACK, and scaLAPACK
+FCL        += -qmkl
+MKLROOT    ?= /mnt/lustre/indy2lfs/sw/intel/compilers_and_libraries_2020.4.304/linux/mkl
+LLIBS_MKL   = -Mmkl -L$(MKLROOT)/lib/intel64 -lmkl_scalapack_lp64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -lmkl_blacs_sgimpt_lp64 -lpthread -lm -ldl
+INCS       += -I$(MKLROOT)/include/fftw
+
+# Use a separate scaLAPACK installation (optional but recommended in combination with OpenMPI)
+# Comment out the two lines below if you want to use scaLAPACK from MKL instead
+# SCALAPACK_ROOT ?= /path/to/your/scalapack/installation
+# LLIBS_MKL   = -L$(SCALAPACK_ROOT)/lib -lscalapack -Mmkl
+
+LLIBS      += $(LLIBS_MKL)
+
+# HDF5-support (optional but strongly recommended)
+#CPP_OPTIONS+= -DVASP_HDF5
+#HDF5_ROOT  ?= /path/to/your/hdf5/installation
+#LLIBS      += -L$(HDF5_ROOT)/lib -lhdf5_fortran
+#INCS       += -I$(HDF5_ROOT)/include
+
+# For the VASP-2-Wannier90 interface (optional)
+#CPP_OPTIONS    += -DVASP2WANNIER90
+#WANNIER90_ROOT ?= /path/to/your/wannier90/installation
+#LLIBS          += -L$(WANNIER90_ROOT)/lib -lwannier
+
+# For the fftlib library (hardly any benefit in combination with MKL's FFTs)
+#CPP_OPTION += -Dsysv
+#FCL         = mpif90 fftlib.o -qmkl
+#CXX_FFTLIB  = icpc -qopenmp -std=c++11 -DFFTLIB_USE_MKL -DFFTLIB_THREADSAFE
+#INCS_FFTLIB = -I./include -I$(MKLROOT)/include/fftw
+#LIBS       += fftlib

--- a/apps/VASP/README.md
+++ b/apps/VASP/README.md
@@ -7,6 +7,7 @@ Build Instructions
 ------------------
 
 * [VASP 6.3.2 Cirrus GPU NVHPC Build Instructions](build_vasp_6.3.2_Cirrus-GPU_NVHPC.md) (recommended build on Cirrus GPU)
+* [VASP 6.3.2 Cirrus Intel Build Instructions](build_vasp_6.3.2_Cirrus_Intel.md)
 * [VASP 6.3.2 ARCHER2 GCC with LibSci Build Instructions](build_vasp_6.3.2_ARCHER2_GCC.md) (recommended build on ARCHER2)
 * [VASP 6.3.1 ARCHER2 GCC with AOCL Build Instructions](build_vasp_6.3.1_ARCHER2_GCC.md)
 * [VASP 6.3.0 ARCHER2 GCC with HPE Cray LibSci Build Instructions](build_vasp_6.3.0_ARCHER2_GCC.md)

--- a/apps/VASP/build_vasp_6.3.2_Cirrus_Intel.md
+++ b/apps/VASP/build_vasp_6.3.2_Cirrus_Intel.md
@@ -1,0 +1,70 @@
+Instructions for compiling VASP 6.3.x for Cirrus using Intel20 compilers
+==========================================================================
+
+These instructions are for compiling VASP 6.3.x on [Cirrus](https://www.cirrus.ac.uk)
+using the Intel compilers including the use of OpenMP
+
+We assume that you have obtained the VASP source code from the VASP website along
+with any relevant patches.
+
+Unpack the VASP source code and apply patches
+---------------------------------------------
+
+Unpack the source
+
+```bash
+tar -xvf vasp.6.3.2.tar.gz
+```
+
+Setup correct modules
+---------------------
+
+```bash
+module load mpt
+module load intel-20.4/compilers
+module load intel-20.4/cmkl
+```
+
+The loaded module list when these instructions were written was:
+
+```bash
+Currently Loaded Modulefiles:
+ 1) git/2.37.3           2) epcc/utils      3) setup-env       4) mpt/2.25              5) intel-license
+ 6) gcc/8.2.0(default)   7) intel-20.4/cc   8) intel-20.4/fc   9) intel-20.4/compilers  10) intel-20.4/cmkl
+```
+
+Create makefile.include
+-----------------------
+
+The new build process for VASP (introduced from version 5.4.1) requires the
+correct options to be set in makefile.include in the root directory of the
+source distribution.
+
+The makefile.include used for the NVHPC compilers on Cirrus GPU can be downloaded from:
+
+* [6.3.2_makefile.include.Cirrus_Intel](6.3.2_makefile.include.Cirrus_Intel)
+
+You should copy this file to the root directory of the VASP source distribution
+and then rename it to "makefile.include":
+
+```bash
+cp 6.3.2_makefile.include.Cirrus_Intel makefile.include
+```
+
+Build VASP
+----------
+
+You build all the VASP executables with:
+
+```bash
+make all
+```
+
+This will produce the following executables in the bin directory:
+
+* `vasp_std` - Multiple k-point version
+* `vasp_gam` - GAMMA-point version
+* `vasp_ncl` - Non-collinear version
+
+
+


### PR DESCRIPTION
Just adds a makefile and assocuated build instructions for Cirrus using Intel compiler. 