### PR TITLE
Load intel/mpi module when building vasp on cirrus

### DIFF
--- a/apps/VASP/build_vasp_6.3.2_Cirrus_Intel.md
+++ b/apps/VASP/build_vasp_6.3.2_Cirrus_Intel.md
@@ -23,6 +23,7 @@ Setup correct modules
 module load mpt
 module load intel-20.4/compilers
 module load intel-20.4/cmkl
+module load intel-20.4/mpi
 ```
 
 The loaded module list when these instructions were written was:
@@ -31,6 +32,7 @@ The loaded module list when these instructions were written was:
 Currently Loaded Modulefiles:
  1) git/2.37.3           2) epcc/utils      3) setup-env       4) mpt/2.25              5) intel-license
  6) gcc/8.2.0(default)   7) intel-20.4/cc   8) intel-20.4/fc   9) intel-20.4/compilers  10) intel-20.4/cmkl
+ 11) intel-20.4/mpi
 ```
 
 Create makefile.include


### PR DESCRIPTION
Just adds a missing module to be loaded when building vasp on cirrus.