### PR TITLE
Add ARCHER2 OpenFOAM(.com) v2212

### DIFF
--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/README.md
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/README.md
@@ -1,0 +1,54 @@
+# OpenFOAM v2212
+
+This is OpenFOAM release of December 2022 (v2212).
+See, e.g., https://www.openfoam.com/news/main-news/openfoam-v2212
+
+
+This directory contains a subdirectory `site` with the
+following scripts which allow one to install and compile OpenFOAM
+using the Gnu compiler collection on Archer2.
+```
+./site/compile.sh
+./site/install.sh
+./site/modules.sh
+./site/prefs.sh
+./site/q-compile.sh
+./site/q-test.sh
+./site/test.sh
+```
+
+You will need to obtain a copy of this directory to proceed.
+
+## Download
+
+In an appropriate directory run the install script:
+```
+$ bash ./site/install.sh
+```
+which will download and unpack the source and third-party packages to the
+current location. The `install` script will also copy the local
+preferences `prefs.sh` to `OpenFOAM-v2212/etc`, and make a small number of
+patches to the third party configuration to allow it to compile. See
+the `install.sh` script for details.
+
+## Compile
+
+Compilation is currently carried out on the front end via
+```
+$ bash ./site/compile.sh
+```
+Note that this will take around 1-2 hours. This can also be submitted
+to the queue system via
+```
+$ sbatch ./site/q-compile.sh
+```
+
+## Example SLURM submission script
+
+A short smoke test `./site/q-test.sh` is provided, which is intended for the
+queue system. The script can be used as a template for jobs to be
+submitted, e.g., via:
+```
+$ sbatch ./site/q-test.sh
+```
+

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/compile.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/compile.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# To be run from FOAM_INST_DIR
+# I make the dependencies first.
+
+source ./site/version.sh
+source ./site/modules.sh
+
+cd OpenFOAM-${version}
+source ./etc/bashrc
+
+
+./Allwmake -j 16 dep
+./Allwmake -j 16 

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/install.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -e
+
+export FOAM_INST_DIR=`pwd`
+source ./site/version.sh
+
+# This takes a few minutes.
+
+wget https://sourceforge.net/projects/openfoam/files/${version}/OpenFOAM-${version}.tgz
+wget https://sourceforge.net/projects/openfoam/files/${version}/ThirdParty-${version}.tgz
+
+tar zxf OpenFOAM-${version}.tgz
+tar zxf ThirdParty-${version}.tgz
+
+# Patch various issues
+
+export FOAM_SRC=${FOAM_INST_DIR}/OpenFOAM-${version}
+export FOAM_THIRDPARTY=${FOAM_INST_DIR}/ThirdParty-${version}
+printf "Install OpenFOAM in FOAM_INST_DIR: %s\n" ${FOAM_INST_DIR}
+
+# Install our site-specific preferences from ./site
+
+cp ./site/prefs.sh ${FOAM_SRC}/etc/prefs.sh
+
+# Thridparty patches
+
+# Scotch
+# Remove the "-m64" from the link stage in the Makefile
+# that is, remove "$(WM_LDFLAGS)"
+
+file=${FOAM_THIRDPARTY}/etc/makeFiles/scotch/Makefile.inc.Linux.shlib
+
+sed -i "s/\$(WM_LDFLAGS)//" ${file}
+
+# We will use FFTW from cray-fftw:
+# fftw_version=fftw-system
+# Remove FFTW_ARCH_PATH
+
+config_file=${FOAM_SRC}/etc/config.sh/FFTW
+
+sed -i "s/^fftw_version.*/fftw_version=fftw-system/" ${config_file}
+sed -i "s/^export FFTW_ARCH_PATH.*//" ${config_file}
+
+# Disable the paraview build cleanly:
+# ParaView_VERSION=none
+
+config_file=${FOAM_SRC}/etc/config.sh/paraview
+
+sed -i "s/^ParaView_VERSION.*/ParaView_VERSION=none/" ${config_file}

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/modules.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/modules.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+# Modules required at build time
+# Use gcc 10.2.0. gcc 11.x has failures.
+
+module load PrgEnv-gnu
+
+# Modules required at compile time and at run time

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/prefs.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/prefs.sh
@@ -1,0 +1,18 @@
+
+
+export WM_MPLIB=CRAY-MPICH
+export WM_COMPILER=Cray
+
+export WM_COMPILER_LIB_ARCH=64
+export WM_CC='cc'
+export WM_CXX='CC'
+export WM_CFLAGS='-fPIC'
+export WM_CXXFLAGS='-fPIC'
+export WM_LDFLAGS=''
+
+# MPI
+# Because ${WM_PROJECT_DIR}/etc/config.sh/mpi is sourced after  this file
+# we need to induce the system to set the appropriate variables:
+
+export MPICH_DIR=${CRAY_MPICH_BASEDIR}
+export MPI_ARCH_PATH=${MPICH_DIR}

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/q-compile.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/q-compile.sh
@@ -1,0 +1,22 @@
+#!/bin/bash --login
+
+#SBATCH --nodes=1
+#SBATCH --exclusive
+#SBATCH --tasks-per-node=1
+#SBATCH --time=03:00:00
+
+printf "Start: %s\n" "`date`"
+
+export FOAM_VERBOSE=1
+
+source ./site/modules.sh
+module list
+
+source ./site/compile.sh
+
+# Record the envoronment variables
+
+set | grep FOAM\_
+set | grep WM\_
+
+printf "Finish: %s\n" "`date`"

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/q-test.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/q-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash --login
+
+#SBATCH --nodes=1
+#SBATCH --exclusive
+#SBATCH --time=00:10:00
+
+#SBATCH --partition=standard
+#SBATCH --qos=standard
+#SBATCH --export=none
+
+#SBATCH --account=z19
+
+set | grep SLURM
+
+printf "Start: %s\n" "`date`"
+
+# Replaces, e.g.,
+
+module load openfoam/com/v2106
+
+# Run test
+
+source ${FOAM_INSTALL_DIR}/etc/bashrc
+
+source ./site/test.sh
+
+printf "Finish: %s\n" "`date`"

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/test.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+# This script itself is not particularly robust to failure.
+
+# Serial test
+mkdir test
+cd test
+cp -r ${FOAM_TUTORIALS}/multiphase/interFoam/laminar/damBreak/damBreak .
+cd damBreak
+blockMesh
+cp -r 0.orig 0
+setFields
+interFoam
+
+# Parallel test
+
+cd ..
+foamCloneCase damBreak damBreakPar
+cd damBreakPar
+setFields
+decomposePar
+srun -n 4 interFoam -parallel

--- a/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/version.sh
+++ b/apps/OpenFOAM/ARCHER2-OpenFOAM-v2212/site/version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# OpenFoam v2212 (December 2022)
+# https://www.openfoam.com/news/main-news/openfoam-v2212
+
+export version="v2212"


### PR DESCRIPTION
Note this has one small difference compared
with previous versions. One of the file names in
the install script related to the ThirdParty
package is changed.

Someone may wish to double-check.

nb. still with `gcc/10.2.0`
