### PR TITLE
LAMMPS 2023-09-23 on ARCHER2 with CPE and python support

### DIFF
--- a/apps/LAMMPS/ARCHER2_2023-09-23_cpe2212.md
+++ b/apps/LAMMPS/ARCHER2_2023-09-23_cpe2212.md
@@ -1,0 +1,84 @@
+Building LAMMPS 23Sep2023 on ARCHER2 (CPE 22.12)
+================================================
+
+These instructions are for building LAMMPS version 23Sep2023, also known as 2aug2023 update 1, on ARCHER2 using the Cray clang compilers 15.0.2 // cpe 22.12.
+
+Download LAMMPS
+---------------
+
+Clone the latest stable version of LAMMPS from the GitHub repository:
+
+```bash
+git clone --depth=1 --branch stable_23Jun2022_update3 https://github.com/lammps/lammps.git lammps-2023-09-23
+```
+
+Setup your environment
+----------------------
+
+Load the correct modules:
+
+```bash
+module load cpe/22.12
+module load cray-fftw/3.3.10.3
+module load cmake/3.21.3
+module load eigen/3.4.0
+module load cray-python
+
+export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+
+# create and source a virtual environment
+python -m venv --system-site-packages /work/ta132/shared/lammps-venv
+source /work/ta132/shared/lammps-venv/bin/activate
+```
+
+Regular MPI executable and python wrappers
+------------------------------------------
+
+Create and go into a build directory:
+
+```bash
+cd lammps-2023-09-23 && mkdir build_cpe && cd build_cpe
+```
+
+Build using:
+
+```bash
+
+cmake -C ../cmake/presets/most.cmake                                       \
+      -D BUILD_MPI=on                                                      \
+      -D BUILD_SHARED_LIBS=yes                                             \
+      -D CMAKE_CXX_COMPILER=CC                                             \
+      -D CMAKE_CXX_FLAGS="-O2"                                             \
+      -D CMAKE_INSTALL_PREFIX=/work/y07/shared/apps/core/lammps/23Sep2023  \
+      -D EIGEN3_INCLUDE_DIR=/work/y07/shared/libs/core/eigen/3.4.0/include \
+      -D FFT=FFTW3                                                         \
+      -D FFTW3_INCLUDE_DIR=${FFTW_INC}                                     \
+      -D FFTW3_LIBRARY=${FFTW_DIR}/libfftw3_mpi.so                         \
+      -D PKG_MPIIO=yes                                                     \
+      ../cmake/
+
+make -j 8
+make install
+make install-python
+```
+
+To run lammps from python
+-------------------------
+
+`LD_PRELOAD` needs to be modified:
+
+```bash
+export LD_PRELOAD=/opt/cray/pe/lib64/libsci_cray_mp.so.5:$LD_PRELOAD
+```
+
+Testing lammps from python
+--------------------------
+
+```bash
+python -i
+>>> import lammps
+>>> lmp = lammps.lammps()
+LAMMPS (23 Jun 2022 - Update 3)
+OMP_NUM_THREADS environment is not set. Defaulting to 1 thread. (src/comm.cpp:98)
+  using 1 OpenMP thread(s) per MPI task
+```

--- a/apps/LAMMPS/Cirrus_2023-09-23_gcc820_impi.md
+++ b/apps/LAMMPS/Cirrus_2023-09-23_gcc820_impi.md
@@ -1,4 +1,5 @@
 Building LAMMPS 23Sep2023 on Cirrus (GCC 8.2.0, FFTW 3.3.10)
+
 ============================================================
 
 
@@ -41,7 +42,7 @@ cmake -C ../cmake/presets/most.cmake \
       -D CMAKE_CXX_FLAGS="-O3"       \
       -D BUILD_MPI=on                \
       -D FFT=FFTW3                   \
-      -D BUILD_SHARED=yes            \
+      -D BUILD_SHARED_LIBS=yes       \
       -D PKG_MPIIO=yes               \
       -D CMAKE_INSTALL_PREFIX=/mnt/lustre/indy2lfs/sw/LAMMPS/23Sep2023-gcc8-impi20 \
       ../cmake/


### PR DESCRIPTION
Instructions for the compilation of LAMMPS 23Sep2023 on ARCHER2, including the MPI-aware python wrapper using a cray-python based virtual environment.