### PR TITLE
OpenMPI 5.0.0.0 

### DIFF
--- a/libs/openmpi/openmpi-5.0.0/Readme.md
+++ b/libs/openmpi/openmpi-5.0.0/Readme.md
@@ -4,7 +4,8 @@ Compilation is best done on the `/home` filesystem.
 On `\work` the timestamps can become inconsistent because Lustre is a network filesystem. OpenMPI requires both `ucx` and `libevent` to be installed. However the versions already present on Cirrus will work and do not need to be reinstalled.
 
 1. Set up 
-Modify the `setup.sh` in order to setup the proper paths where you want to install openmpi and its dependencies.
+
+Modify the `setup.sh` file in order to setup the proper paths where you want to install openmpi and its dependencies.
 
 1. Install hwloc
 

--- a/libs/openmpi/openmpi-5.0.0/Readme.md
+++ b/libs/openmpi/openmpi-5.0.0/Readme.md
@@ -1,0 +1,25 @@
+# OpenMPI 5.0.0 on Cirrus
+
+Compilation is best done on the `/home` filesystem.
+On `\work` the timestamps can become inconsistent because Lustre is a network filesystem. OpenMPI requires both `ucx` and `libevent` to be installed. However the versions already present on Cirrus will work and do not need to be reinstalled.
+
+1. Set up 
+Modify the `setup.sh` in order to setup the proper paths where you want to install openmpi and its dependencies.
+
+1. Install hwloc
+
+```bash 
+cd hwloc && bash ./install.sh && cd ..
+```
+
+2. Install pmix
+
+```bash 
+cd pmix && bash ./install.sh && cd ..
+```
+
+3. Install openmpi
+
+```bash 
+cd openmpi && bash ./install.sh && cd ..
+```

--- a/libs/openmpi/openmpi-5.0.0/hwloc/install.sh
+++ b/libs/openmpi/openmpi-5.0.0/hwloc/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/bash
+
+source ../setup.sh
+
+wget https://download.open-mpi.org/release/hwloc/v2.9/hwloc-$HWLOC_VERSION.tar.gz .
+
+tar xvf hwloc-$HWLOC_VERSION.tar.gz
+
+
+cd hwloc-$HWLOC_VERSION
+mkdir build
+cd build
+
+../configure --prefix=${HWLOC_ROOT}
+make 
+make install

--- a/libs/openmpi/openmpi-5.0.0/openmpi/install.sh
+++ b/libs/openmpi/openmpi-5.0.0/openmpi/install.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+
+set -e
+
+source ../setup.sh
+
+
+
+
+CFLAGS="-I${HWLOC_ROOT}/include -I${PMIX_ROOT}/include"
+LDFLAGS="-L${PMIX_ROOT}/lib -L${HWLOC_ROOT}/lib"
+
+
+CONF="CC=${CC} CXX=${CXX} FC=${FC} "\
+'--enable-mpi1-compatibility '\
+'--enable-mpi-fortran '\
+'--enable-mpi-interface-warning '\
+'--enable-mpirun-prefix-by-default --with-slurm '\
+'--with-ucx=/mnt/lustre/indy2lfs/sw/ucx/1.15.0 '\
+"--with-pmix=${PMIX_ROOT} "\
+"--with-pmix-libdir=${PMIX_ROOT}/lib "\
+'--with-libevent=/mnt/lustre/indy2lfs/sw/libevent/2.1.12 '\
+"--with-hwloc=${HWLOC_ROOT} "\
+"--without-cuda --without-hcoll"
+
+OMPI="openmpi-${OPENMPI_VERSION}"
+
+
+wget https://download.open-mpi.org/release/open-mpi/v`echo $OPENMPI_VERSION | cut -c1-3`/${OMPI}.tar.gz
+tar -xvf ${OMPI}.tar.gz
+cd ${OMPI}
+mkdir build
+cd build
+../configure CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" $CONF --prefix=${OPENMPI_ROOT}
+make 2>&1 | tee make.log
+make install

--- a/libs/openmpi/openmpi-5.0.0/pmix/install.sh
+++ b/libs/openmpi/openmpi-5.0.0/pmix/install.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+set -e 
+
+source ../setup.sh
+
+
+PMIX=pmix-$PMIX_VERSION
+wget https://github.com/openpmix/openpmix/releases/download/v${PMIX_VERSION}/$PMIX.tar.gz
+
+
+tar -xvf ${PMIX}.tar.gz 
+cd $PMIX
+mkdir build
+cd build
+
+../configure CFLAGS="-I${HWLOC_ROOT}/include" LDFLAGS="-L${HWLOC_ROOT}/lib" --with-hwloc=${HWLOC_ROOT} --with-libevent=${LIBEVENT_ROOT} --prefix=${PMIX_ROOT}
+make 
+make install
+

--- a/libs/openmpi/openmpi-5.0.0/setup.sh
+++ b/libs/openmpi/openmpi-5.0.0/setup.sh
@@ -1,0 +1,25 @@
+module load gcc/10.2.0
+
+export BASE_PREFIX=/mnt/lustre/indy2lfs/sw # Base directory where to install openmpi and its dependencies, not already available on cirrus
+
+# Define compilers
+export CC=gcc 
+export CXX=g++
+export FC=gfortran
+
+CC_VERSION=$($CC --version | head -n 1 |  awk '{ print $3}') # get the version from the executable. This is used to define the path of all libraries required by the install
+
+
+HWLOC_VERSION=2.9.3
+HWLOC_ROOT=${BASE_PREFIX}/hwloc/hwloc-${HWLOC_VERSION}-${CC}-${CC_VERSION}
+
+
+PMIX_VERSION=4.2.7
+PMIX_ROOT=${BASE_PREFIX}/pmix/pmix-${PMIX_VERSION}-${CC}-${CC_VERSION}
+
+LIBEVENT_ROOT=/mnt/lustre/indy2lfs/sw/libevent/2.1.12
+
+OPENMPI_VERSION=5.0.0
+OPENMPI_ROOT=${BASE_PREFIX}/openmpi/openmpi-${OPENMPI_VERSION}-${CC}-${CC_VERSION}
+
+


### PR DESCRIPTION
I have added build instructions for installing OpenMPI 5.0.0 on Cirrus ( using pmix) , without slurm support.