### PR TITLE
Update and rename build_fftw3.3.10_cirrus_gcc8.2_mpt2.25.md to build_…

### DIFF
--- a/libs/fftw/build_fftw3.3.10_cirrus_gcc10.2_mpt2.25.md
+++ b/libs/fftw/build_fftw3.3.10_cirrus_gcc10.2_mpt2.25.md
@@ -1,5 +1,5 @@
 
-# Build fftw-3.3.10 on Cirrus with GCC 8.2 and MPT 2.25
+# Build fftw-3.3.10 on Cirrus with GCC 10.2 and MPT 2.25
 
 Download and untar source code
 ```
@@ -10,13 +10,13 @@ cd fftw-3.3.10/
 
 Set-up module environment
 ```
-module load gcc/8.2.0
+module load gcc/10.2.0
 module load mpt/2.25
 ```
 
 Configure and build
 ```
-./configure --prefix=/work/y07/shared/cirrus-software/fftw/3.3.10-gcc8.2-mpt2.25 \
+./configure --prefix=/work/y07/shared/cirrus-software/fftw/3.3.10-gcc10.2-mpt2.25 \
 --enable-mpi --enable-openmp --enable-threads --enable-shared \
 LDFLAGS=-L/opt/hpe/hpc/mpt/mpt-2.25/lib:$LD_LIBRARY_PATH CPPFLAGS=-I/opt/hpe/hpc/mpt/mpt-2.25/include MPILIBS=-lmpi
 


### PR DESCRIPTION
…fftw3.3.10_cirrus_gcc10.2_mpt2.25.md

version fixed for gcc 10.2.