### PR TITLE
Revert use of LINKER_FLAGS env_var

### DIFF
--- a/apps/LAMMPS/Cirrus_2023-12-15_gcc10.2_impi20.4.md
+++ b/apps/LAMMPS/Cirrus_2023-12-15_gcc10.2_impi20.4.md
@@ -31,14 +31,13 @@ MPI Version
 Make and go into a build directory:
 
 ```bash
-cd lammps-2023-09-23 && mkdir build_gcc_impi && cd build_gcc_impi
+cd lammps-2023-12-15 && mkdir build_gcc_impi && cd build_gcc_impi
 ```
 
 Build using:
 
 ```bash
 export LAMMPS_INSTALL=/work/y07/shared/cirrus-software/lammps/15Dec2023_gcc10.2_impi20.4
-export LINKER_FLAGS="-m64 -L${MKLROOT}/lib/intel64 -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl "
 
 cmake -C ../cmake/presets/most.cmake            \
       -D BUILD_MPI=on                           \
@@ -47,7 +46,7 @@ cmake -C ../cmake/presets/most.cmake            \
       -D CMAKE_CXX_COMPILER=mpicxx              \
       -D CMAKE_C_COMPILER=mpicc                 \
       -D CMAKE_Fortran_COMPILER=mpif90          \
-      -D CMAKE_EXE_LINKER_FLAGS=${LINKER_FLAGS} \
+      -D CMAKE_EXE_LINKER_FLAGS="-m64 -L${MKLROOT}/lib/intel64 -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl " \
       -D FFT=FFTW3                              \
       -D PKG_MPIIO=yes                          \
       -D CMAKE_INSTALL_PREFIX=${LAMMPS_INSTALL} \

--- a/apps/LAMMPS/Cirrus_2023-12-15_gcc10.2_impi20.4_cuda118.md
+++ b/apps/LAMMPS/Cirrus_2023-12-15_gcc10.2_impi20.4_cuda118.md
@@ -32,14 +32,13 @@ Compilation and installation
 Make and go into a build directory:
 
 ```bash
-cd lammps-2023-09-23 && mkdir build_cuda && cd build_cuda
+cd lammps-2023-12-15 && mkdir build_cuda && cd build_cuda
 ```
 
 Build using:
 
 ```bash
 export LAMMPS_INSTALL=/work/y07/shared/cirrus-software/lammps/15Dec2023_gcc10.2_impi20.4_cuda11.8
-export LINKER_FLAGS="-m64 -L${MKLROOT}/lib/intel64 -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl "
 
 cmake -C ../cmake/presets/most.cmake            \
       -D BUILD_MPI=on                           \
@@ -48,7 +47,7 @@ cmake -C ../cmake/presets/most.cmake            \
       -D CMAKE_CXX_COMPILER=mpicxx              \
       -D CMAKE_C_COMPILER=mpicc                 \
       -D CMAKE_Fortran_COMPILER=mpif90          \
-      -D CMAKE_EXE_LINKER_FLAGS=${LINKER_FLAGS} \
+      -D CMAKE_EXE_LINKER_FLAGS="-m64 -L${MKLROOT}/lib/intel64 -lmkl_gf_lp64 -lmkl_gnu_thread -lmkl_core -lgomp -lpthread -lm -ldl " \
       -D FFT=FFTW3                              \
       -D PKG_MPIIO=yes                          \
       -D PKG_GPU=yes                            \


### PR DESCRIPTION
It breaks compilation