### PR TITLE
Clang build instructions 18.1.8

### DIFF
--- a/utils/clang/README.md
+++ b/utils/clang/README.md
@@ -1,0 +1,20 @@
+GCC
+===
+
+This folder contains files and documentation for building and maintaining GCC on Cirrus.
+
+History
+-------
+
+Date | System | Person | Version | Notes
+---- | ------ |-------|---------|------
+2016-11-07 | Cirrus (EPCC) | Luca Parisi| 18.1.8 | Contains instructions for cuda support
+
+Build Instructions
+------------------
+
+* [Cirrus clang 18.1.8 Build Instructions](build_18.1.8.md)
+
+Notes
+-----
+

--- a/utils/clang/README.md
+++ b/utils/clang/README.md
@@ -8,7 +8,7 @@ History
 
 Date | System | Person | Version | Notes
 ---- | ------ |-------|---------|------
-2016-11-07 | Cirrus (EPCC) | Luca Parisi| 18.1.8 | Contains instructions for cuda support
+2024-08-19 | Cirrus (EPCC) | Luca Parisi| 18.1.8 | Contains instructions for cuda support
 
 Build Instructions
 ------------------

--- a/utils/clang/build_18.1.8.md
+++ b/utils/clang/build_18.1.8.md
@@ -1,0 +1,62 @@
+Instructions for compiling GCC 6.*
+==================================
+
+These instructions are for compiling clang 18.1.8 on Cirrus.
+
+**Note:** This Clang build from source takes quite a long time!
+
+Setup the environment
+-----------------------
+
+```bash
+module load gcc/10.2.0
+module load cmake/3.25.2
+VERSION=18.1.8
+INSTALL_DIR=<you_path_were_to_install_clang>
+```
+
+Download
+---------------------
+
+```bash
+git clone https://github.com/llvm/llvm-project.git
+cd llvm-project
+git checkout tags/llvmorg-$VERSION
+cd ../
+```
+
+Configure
+---------------------------------------
+
+```bash
+mkdir -p  build
+cd build
+
+export CPATH=/work/y07/shared/cirrus-software/gcc/10.2.0/include/c++/10.2.0:/work/y07/shared/cirrus-software/gcc/10.2.0/include/c++/10.2.0/x86_64-pc-linux-gnu:$CPATH
+cmake ../llvm-project/llvm -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="openmp"  -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR -DCLANG_CONFIG_FILE_SYSTEM_DIR=$INSTALL_DIR/etc
+```
+
+Build and Install
+-----------------
+
+```bash
+make -j 8
+make install
+```
+
+Configuration ( optional )
+--------------------------------
+Optionally, you can set a configuration file in the `$INSTALL_DIR/etc` directory named `clang++.cfg` and `clang.cfg` , respectively for the C++/C compiler. The configuration file contains a list of default flags to be passed to the compiler.
+We provide two configuration files:
+
+- [clang-gcc10.cfg](clang-gcc10.cfg): configuration for this build with gcc 10
+- [clang-gcc10-cuda12.4.cfg](clang-gcc10-cuda12.4.cfg) : as above, but also pointing at the cuda installation in nvhpc 24.5
+
+To install these configurations use
+
+```bash
+
+cp <my_config.cfg> $INSTALL_DIR/etc/clang++.cfg
+cp <my_config.cfg> $INSTALL_DIR/etc/clang.cfg
+
+```

--- a/utils/clang/clang-gcc10-cuda12.4.cfg
+++ b/utils/clang/clang-gcc10-cuda12.4.cfg
@@ -1,0 +1,4 @@
+--cuda-path=/work/y07/shared/cirrus-software/nvidia/hpcsdk-24.5/Linux_x86_64/24.5/cuda/12.4
+-I /work/y07/shared/cirrus-software/gcc/10.2.0/include/c++/10.2.0
+-I /work/y07/shared/cirrus-software/gcc/10.2.0/include/c++/10.2.0/x86_64-pc-linux-gnu
+--offload-arch=sm_70

--- a/utils/clang/clang-gcc10.cfg
+++ b/utils/clang/clang-gcc10.cfg
@@ -1,0 +1,3 @@
+-I /work/y07/shared/cirrus-software/gcc/10.2.0/include/c++/10.2.0
+-I /work/y07/shared/cirrus-software/gcc/10.2.0/include/c++/10.2.0/x86_64-pc-linux-gnu
+--offload-arch=sm_70


### PR DESCRIPTION
Added instructions for building clang 18.1.8, including instructions for configuring compiling with cuda .
